### PR TITLE
DOTS-509 Add security scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,6 +545,45 @@ security-scan-image:  ## REPOSITORY[name of image task or tester] UNACCEPTABLE_V
 	fi
 	make aws-ecr-get-security-scan-local REPOSITORY=$(REPOSITORY) TAG=$$tag UNACCEPTABLE_VULNERABILITY_LEVELS=$(UNACCEPTABLE_VULNERABILITY_LEVELS) FAIL_ON_WARNINGS=true
 
+dummy:  ## THRESHOLD_LEVEL
+	VULNERABILITY_LEVELS=("UNDEFINED","INFORMATIONAL","LOW","MEDIUM","HIGH","CRITICAL")
+	make -s aws-ecr-wait-for-image-scan-complete REPOSITORY=$(REPOSITORY) TAG=$(TAG)
+	SCAN_FINDINGS=$$(make -s aws-ecr-describe-image-scan-findings REPOSITORY=$(REPOSITORY) TAG=$(TAG))
+	SCAN_WARNINGS=$$(echo $$SCAN_FINDINGS | jq '.imageScanFindings.findingSeverityCounts')
+	CRITICAL=$$(echo $$SCAN_WARNINGS | jq '.CRITICAL')
+	HIGH=$$(echo $$SCAN_WARNINGS | jq '.HIGH')
+	MEDIUM=$$(echo $$SCAN_WARNINGS | jq '.MEDIUM')
+	LOW=$$(echo $$SCAN_WARNINGS | jq '.LOW')
+	INFORMATIONAL=$$(echo $$SCAN_WARNINGS | jq '.INFORMATIONAL')
+	UNDEFINED=$$(echo $$SCAN_WARNINGS | jq '.UNDEFINED')
+	if [[ "$(SHOW_ALL_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
+		echo "CRITICAL: $$CRITICAL"
+		echo "HIGH: $$HIGH"
+		echo "MEDIUM: $$MEDIUM"
+		echo "LOW: $$LOW"
+		echo "INFORMATIONAL: $$INFORMATIONAL"
+		echo "UNDEFINED: $$UNDEFINED"
+	fi
+	THRESHOLD_CROSSED=false
+	IS_UNACCEPTABLE_WARNINGS=false
+	for LEVEL in $$(echo $$VULNERABILITY_LEVELS | tr "," "\n" | tr [:lower:] [:upper:]); do
+
+			if [ $$LEVEL == $(THRESHOLD_LEVEL) ]  || [ $$THRESHOLD_CROSSED == "true" ] ; then
+				THRESHOLD_CROSSED=true
+				if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ] ; then
+					IS_UNACCEPTABLE_WARNINGS=true
+					echo $$LEVEL vulnerabilities reported
+				fi
+			else
+				echo $$LEVEL
+			fi
+	done
+	echo "For more details visit https://$(AWS_REGION).console.aws.amazon.com/ecr/repositories/private/$(AWS_ACCOUNT_ID_MGMT)/$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY)?region=$(AWS_REGION)"
+	if [[ "$(FAIL_ON_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]] && [ $$IS_UNACCEPTABLE_WARNINGS == "true" ]; then
+		exit 1
+	fi
+
+# if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ]; then
 # ==================
 # Temporary until brought in from devops library
 # ===================

--- a/Makefile
+++ b/Makefile
@@ -572,60 +572,7 @@ aws-ecr-get-security-threshold-scan:  ## Reports if vulnerabilities exist at thr
 		exit 1
 	fi
 
-# ==================
-# Temporary until brought in from devops library
-# ===================
 
-# aws-ecr-get-security-scan-local: ### Fetches container scan report and returns findings - Mandatory REPOSITORY, TAG=[image tag], UNACCEPTABLE_VULNERABILITY_LEVELS=[LOW,MEDIUM,HIGH,CRITICAL]; optional: FAIL_ON_WARNINGS=false, SHOW_ALL_WARNINGS=false
-# 	make -s aws-ecr-wait-for-image-scan-complete REPOSITORY=$(REPOSITORY) TAG=$(TAG)
-# 	SCAN_FINDINGS=$$(make -s aws-ecr-describe-image-scan-findings REPOSITORY=$(REPOSITORY) TAG=$(TAG))
-# 	SCAN_WARNINGS=$$(echo $$SCAN_FINDINGS | jq '.imageScanFindings.findingSeverityCounts')
-# 	CRITICAL=$$(echo $$SCAN_WARNINGS | jq '.CRITICAL')
-# 	HIGH=$$(echo $$SCAN_WARNINGS | jq '.HIGH')
-# 	MEDIUM=$$(echo $$SCAN_WARNINGS | jq '.MEDIUM')
-# 	LOW=$$(echo $$SCAN_WARNINGS | jq '.LOW')
-# 	INFORMATIONAL=$$(echo $$SCAN_WARNINGS | jq '.INFORMATIONAL')
-# 	UNDEFINED=$$(echo $$SCAN_WARNINGS | jq '.UNDEFINED')
-# 	if [[ "$(SHOW_ALL_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
-# 		echo "CRITICAL: $$CRITICAL"
-# 		echo "HIGH: $$HIGH"
-# 		echo "MEDIUM: $$MEDIUM"
-# 		echo "LOW: $$LOW"
-# 		echo "INFORMATIONAL: $$INFORMATIONAL"
-# 		echo "UNDEFINED: $$UNDEFINED"
-# 	fi
-# 	IS_UNACCEPTABLE_WARNINGS=false
-# 	for LEVEL in $$(echo $(UNACCEPTABLE_VULNERABILITY_LEVELS) | tr "," "\n" | tr [:lower:] [:upper:]); do
-# 		if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ]; then
-# 			echo $$LEVEL is above the threshold
-# 			IS_UNACCEPTABLE_WARNINGS=true
-# 		fi
-# 	done
-# 	echo "For more details visit https://$(AWS_REGION).console.aws.amazon.com/ecr/repositories/private/$(AWS_ACCOUNT_ID_MGMT)/$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY)?region=$(AWS_REGION)"
-# 	if [[ "$(FAIL_ON_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]] && [ $$IS_UNACCEPTABLE_WARNINGS == "true" ]; then
-# 		exit 1
-# 	fi
-
-aws-ecr-wait-for-image-scan-complete: ### Waits for ECR image scan report - REPOSITORY, TAG=[image tag]
-	make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
-			$(AWSCLI) ecr wait image-scan-complete \
-			--registry-id $(AWS_ACCOUNT_ID_MGMT) \
-			--repository-name $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY) \
-			--image-id imageTag=$(TAG) \
-			--output json \
-		"
-
-aws-ecr-describe-image-scan-findings: ### Describes ECR image scan report - REPOSITORY, TAG=[image tag]
-		make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
-			$(AWSCLI) ecr describe-image-scan-findings \
-			--registry-id $(AWS_ACCOUNT_ID_MGMT) \
-			--repository-name $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY) \
-			--image-id imageTag=$(TAG) \
-			--output json \
-		"
-# ===================
-# end temp
-# ===================
 # ==============================================================================
 # Supporting targets
 

--- a/Makefile
+++ b/Makefile
@@ -557,24 +557,18 @@ aws-ecr-get-security-threshold-scan:  ## Reports if vulnerabilities exist at thr
 	INFORMATIONAL=$$(echo $$SCAN_WARNINGS | jq '.INFORMATIONAL')
 	UNDEFINED=$$(echo $$SCAN_WARNINGS | jq '.UNDEFINED')
 	THRESHOLD_CROSSED=false
-	IS_UNACCEPTABLE_WARNINGS=false
+	VULNERABLE=false
 	for LEVEL in $$(echo $$VULNERABILITY_LEVELS | tr "," "\n" | tr [:lower:] [:upper:]); do
 			if [ $$LEVEL == $(THRESHOLD_LEVEL) ]  || [ $$THRESHOLD_CROSSED == "true" ] ; then
 				THRESHOLD_CROSSED=true
 				if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ] ; then
-					IS_UNACCEPTABLE_WARNINGS=true
+					VULNERABLE=true
 					echo $$LEVEL vulnerabilities reported
-					echo "CRITICAL: $$CRITICAL"
-					echo "HIGH: $$HIGH"
-					echo "MEDIUM: $$MEDIUM"
-					echo "LOW: $$LOW"
-					echo "INFORMATIONAL: $$INFORMATIONAL"
-					echo "UNDEFINED: $$UNDEFINED"
 				fi
 			fi
 	done
 	echo "For more details visit https://$(AWS_REGION).console.aws.amazon.com/ecr/repositories/private/$(AWS_ACCOUNT_ID_MGMT)/$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY)?region=$(AWS_REGION)"
-	if [[ "$(FAIL_ON_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]] && [ $$IS_UNACCEPTABLE_WARNINGS == "true" ]; then
+	if [[ "$(FAIL_ON_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]] && [ $$VULNERABLE == "true" ]; then
 		exit 1
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -556,26 +556,21 @@ dummy:  ## THRESHOLD_LEVEL
 	LOW=$$(echo $$SCAN_WARNINGS | jq '.LOW')
 	INFORMATIONAL=$$(echo $$SCAN_WARNINGS | jq '.INFORMATIONAL')
 	UNDEFINED=$$(echo $$SCAN_WARNINGS | jq '.UNDEFINED')
-	if [[ "$(SHOW_ALL_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
-		echo "CRITICAL: $$CRITICAL"
-		echo "HIGH: $$HIGH"
-		echo "MEDIUM: $$MEDIUM"
-		echo "LOW: $$LOW"
-		echo "INFORMATIONAL: $$INFORMATIONAL"
-		echo "UNDEFINED: $$UNDEFINED"
-	fi
 	THRESHOLD_CROSSED=false
 	IS_UNACCEPTABLE_WARNINGS=false
 	for LEVEL in $$(echo $$VULNERABILITY_LEVELS | tr "," "\n" | tr [:lower:] [:upper:]); do
-
 			if [ $$LEVEL == $(THRESHOLD_LEVEL) ]  || [ $$THRESHOLD_CROSSED == "true" ] ; then
 				THRESHOLD_CROSSED=true
 				if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ] ; then
 					IS_UNACCEPTABLE_WARNINGS=true
 					echo $$LEVEL vulnerabilities reported
+					echo "CRITICAL: $$CRITICAL"
+					echo "HIGH: $$HIGH"
+					echo "MEDIUM: $$MEDIUM"
+					echo "LOW: $$LOW"
+					echo "INFORMATIONAL: $$INFORMATIONAL"
+					echo "UNDEFINED: $$UNDEFINED"
 				fi
-			else
-				echo $$LEVEL
 			fi
 	done
 	echo "For more details visit https://$(AWS_REGION).console.aws.amazon.com/ecr/repositories/private/$(AWS_ACCOUNT_ID_MGMT)/$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY)?region=$(AWS_REGION)"
@@ -583,7 +578,6 @@ dummy:  ## THRESHOLD_LEVEL
 		exit 1
 	fi
 
-# if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ]; then
 # ==================
 # Temporary until brought in from devops library
 # ===================

--- a/Makefile
+++ b/Makefile
@@ -537,6 +537,68 @@ task-type: # Return the type of task cron/hk - mandatory: NAME=[name of task]
 		exit 1
 	fi
 
+security-scan-image:  ## REPOSITORY[name of image task or tester] UNACCEPTABLE_VULNERABILITY_LEVELS=[LOW,MEDIUM,HIGH,CRITICAL]
+	if [ -z "$(TAG)" ]; then
+		tag=latest
+	else
+		tag=$(TAG)
+	fi
+	make aws-ecr-get-security-scan-local REPOSITORY=$(REPOSITORY) TAG=$$tag UNACCEPTABLE_VULNERABILITY_LEVELS=$(UNACCEPTABLE_VULNERABILITY_LEVELS) FAIL_ON_WARNINGS=true
+
+# ==================
+# Temporary until brought in from devops library
+# ===================
+
+aws-ecr-get-security-scan-local: ### Fetches container scan report and returns findings - Mandatory REPOSITORY, TAG=[image tag], UNACCEPTABLE_VULNERABILITY_LEVELS=[LOW,MEDIUM,HIGH,CRITICAL]; optional: FAIL_ON_WARNINGS=false, SHOW_ALL_WARNINGS=false
+	make -s aws-ecr-wait-for-image-scan-complete REPOSITORY=$(REPOSITORY) TAG=$(TAG)
+	SCAN_FINDINGS=$$(make -s aws-ecr-describe-image-scan-findings REPOSITORY=$(REPOSITORY) TAG=$(TAG))
+	SCAN_WARNINGS=$$(echo $$SCAN_FINDINGS | jq '.imageScanFindings.findingSeverityCounts')
+	CRITICAL=$$(echo $$SCAN_WARNINGS | jq '.CRITICAL')
+	HIGH=$$(echo $$SCAN_WARNINGS | jq '.HIGH')
+	MEDIUM=$$(echo $$SCAN_WARNINGS | jq '.MEDIUM')
+	LOW=$$(echo $$SCAN_WARNINGS | jq '.LOW')
+	INFORMATIONAL=$$(echo $$SCAN_WARNINGS | jq '.INFORMATIONAL')
+	UNDEFINED=$$(echo $$SCAN_WARNINGS | jq '.UNDEFINED')
+	if [[ "$(SHOW_ALL_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]]; then
+		echo "CRITICAL: $$CRITICAL"
+		echo "HIGH: $$HIGH"
+		echo "MEDIUM: $$MEDIUM"
+		echo "LOW: $$LOW"
+		echo "INFORMATIONAL: $$INFORMATIONAL"
+		echo "UNDEFINED: $$UNDEFINED"
+	fi
+	IS_UNACCEPTABLE_WARNINGS=false
+	for LEVEL in $$(echo $(UNACCEPTABLE_VULNERABILITY_LEVELS) | tr "," "\n" | tr [:lower:] [:upper:]); do
+		if [ "$$(echo $$(eval echo \"\$$$$LEVEL\"))" != null ]; then
+			echo $$LEVEL is above the threshold
+			IS_UNACCEPTABLE_WARNINGS=true
+		fi
+	done
+	echo "For more details visit https://$(AWS_REGION).console.aws.amazon.com/ecr/repositories/private/$(AWS_ACCOUNT_ID_MGMT)/$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY)?region=$(AWS_REGION)"
+	if [[ "$(FAIL_ON_WARNINGS)" =~ ^(true|yes|y|on|1|TRUE|YES|Y|ON)$$ ]] && [ $$IS_UNACCEPTABLE_WARNINGS == "true" ]; then
+		exit 1
+	fi
+
+aws-ecr-wait-for-image-scan-complete: ### Waits for ECR image scan report - REPOSITORY, TAG=[image tag]
+	make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
+			$(AWSCLI) ecr wait image-scan-complete \
+			--registry-id $(AWS_ACCOUNT_ID_MGMT) \
+			--repository-name $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY) \
+			--image-id imageTag=$(TAG) \
+			--output json \
+		"
+
+aws-ecr-describe-image-scan-findings: ### Describes ECR image scan report - REPOSITORY, TAG=[image tag]
+		make -s docker-run-tools ARGS="$$(echo $(AWSCLI) | grep awslocal > /dev/null 2>&1 && echo '--env LOCALSTACK_HOST=$(LOCALSTACK_HOST)' ||:)" CMD=" \
+			$(AWSCLI) ecr describe-image-scan-findings \
+			--registry-id $(AWS_ACCOUNT_ID_MGMT) \
+			--repository-name $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$(REPOSITORY) \
+			--image-id imageTag=$(TAG) \
+			--output json \
+		"
+# ===================
+# end temp
+# ===================
 # ==============================================================================
 # Supporting targets
 

--- a/build/jenkins/Jenkinsfile.hk-integration
+++ b/build/jenkins/Jenkinsfile.hk-integration
@@ -33,6 +33,7 @@ pipeline {
         SLACK_CHANNEL = 'dos-tasks-integration-notifications'
         PATHWAYSDOS_V4_BRANCH = 'develop'
         BRANCH_NAME = sh(returnStdout: true, script: "make git-branch-format BRANCH_NAME=${GIT_BRANCH}").trim()
+        VULNERABILITY_THRESHOLD_LEVEL = "HIGH"
     }
     triggers { pollSCM("* * * * *") }
     stages {
@@ -67,6 +68,22 @@ pipeline {
                 script { sh "make unit-test TASK=${TASK}" }
                 script { sh "make build TASK=${TASK}" }
                 script { sh "make push TASK=${TASK}" }
+            }
+        }
+        stage("Check for vulnerabilities") {
+            steps {
+                script {
+                    echo 'Checking for vulnerabilities in latest docker image used for all tasks'
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        sh "make security-scan-image REPOSITORY=hk-filter THRESHOLD_LEVEL==${VULNERABILITY_THRESHOLD_LEVEL} FAIL_ON_WARNINGS=true"
+                    }
+                }
+                script {
+                    echo 'Checking for vulnerabilities in latest docker image used for testing'
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        sh "make security-scan-image REPOSITORY=tester THRESHOLD_LEVEL==${VULNERABILITY_THRESHOLD_LEVEL} FAIL_ON_WARNINGS=true"
+                    }
+                }
             }
         }
         stage('Check key infrastructure exists') {

--- a/build/jenkins/Jenkinsfile.nonprod
+++ b/build/jenkins/Jenkinsfile.nonprod
@@ -17,6 +17,7 @@ pipeline {
     ENVIRONMENT = "nonprod"
     TASK = "${params.Task}"
     DB_NAME = "${params.Database}"
+    UNACCEPTABLE_VULNERABILITY_LEVELS = "HIGH,CRITICAL"
   }
   triggers { pollSCM("* * * * *") }
   stages {
@@ -34,6 +35,25 @@ pipeline {
         script { sh "make push TASK=${params.Task}" }
       }
     }
+
+    stage("Check") {
+      when { expression { params.Task != "none" } }
+      steps {
+        script {
+            echo 'Checking for vulnerabilities in latest docker image used for all tasks'
+            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                sh "make security-scan-image REPOSITORY=hk-filter UNACCEPTABLE_VULNERABILITY_LEVELS=${UNACCEPTABLE_VULNERABILITY_LEVELS}"
+            }
+        }
+        script {
+            echo 'Checking for vulnerabilities in latest docker image used for testing'
+            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                sh "make security-scan-image REPOSITORY=tester UNACCEPTABLE_VULNERABILITY_LEVELS=${UNACCEPTABLE_VULNERABILITY_LEVELS}"
+            }
+        }
+      }
+    }
+
 
     stage("Test") {
       when { expression { params.Task != "none" } }

--- a/build/jenkins/Jenkinsfile.nonprod
+++ b/build/jenkins/Jenkinsfile.nonprod
@@ -17,7 +17,7 @@ pipeline {
     ENVIRONMENT = "nonprod"
     TASK = "${params.Task}"
     DB_NAME = "${params.Database}"
-    UNACCEPTABLE_VULNERABILITY_LEVELS = "HIGH,CRITICAL"
+    VULNERABILITY_THRESHOLD_LEVEL = "HIGH"
   }
   triggers { pollSCM("* * * * *") }
   stages {
@@ -42,13 +42,13 @@ pipeline {
         script {
             echo 'Checking for vulnerabilities in latest docker image used for all tasks'
             catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                sh "make security-scan-image REPOSITORY=hk-filter UNACCEPTABLE_VULNERABILITY_LEVELS=${UNACCEPTABLE_VULNERABILITY_LEVELS}"
+                sh "make security-scan-image REPOSITORY=hk-filter THRESHOLD_LEVEL==${VULNERABILITY_THRESHOLD_LEVEL} FAIL_ON_WARNINGS=true"
             }
         }
         script {
             echo 'Checking for vulnerabilities in latest docker image used for testing'
             catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                sh "make security-scan-image REPOSITORY=tester UNACCEPTABLE_VULNERABILITY_LEVELS=${UNACCEPTABLE_VULNERABILITY_LEVELS}"
+                sh "make security-scan-image REPOSITORY=tester THRESHOLD_LEVEL==${VULNERABILITY_THRESHOLD_LEVEL} FAIL_ON_WARNINGS=true"
             }
         }
       }

--- a/build/jenkins/Jenkinsfile.nonprod
+++ b/build/jenkins/Jenkinsfile.nonprod
@@ -36,7 +36,7 @@ pipeline {
       }
     }
 
-    stage("Check") {
+    stage("Check for vulnerabilities") {
       when { expression { params.Task != "none" } }
       steps {
         script {

--- a/build/jenkins/Jenkinsfile.nonprod
+++ b/build/jenkins/Jenkinsfile.nonprod
@@ -54,7 +54,6 @@ pipeline {
       }
     }
 
-
     stage("Test") {
       when { expression { params.Task != "none" } }
       steps {


### PR DESCRIPTION
Stage added to standard build/push/deploy pipeline to run security scan on the task image (used by various hk or cron jobs) and the tester image - used for dev testing. The pipeline will report as a failed stage if either image has vulnerabilities at level HIGH or higher