### PR TITLE
DLS-683 Change security group

### DIFF
--- a/application/utilities/database.py
+++ b/application/utilities/database.py
@@ -148,7 +148,7 @@ class DB:
             else:
                 connection_details_set = False
                 logger.log_for_diagnostics(env, "No DB_PASSWORD secret set")
-            if profile != "prod" and env != "performance":
+            if profile != "live" and env != "performance":
                 self.db_name = "pathwaysdos_{}".format(env)
             else:
                 self.db_name = "pathwaysdos"

--- a/build/automation/lib/python.mk
+++ b/build/automation/lib/python.mk
@@ -5,7 +5,7 @@ PYTHON_VERSION = $(PYTHON_VERSION_MAJOR).$(PYTHON_VERSION_MINOR).$(PYTHON_VERSIO
 PYTHON_BASE_PACKAGES = \
 	awscli-local==0.18 \
 	awscli==1.22.64 \
-	black==22.1.0 \
+	black==22.3.0 \
 	boto3==1.21.9 \
 	bpython \
 	configparser \

--- a/build/automation/var/profile/integration.mk
+++ b/build/automation/var/profile/integration.mk
@@ -32,11 +32,7 @@ TF_VAR_hk_integration_tester_lambda_function_name = $(PROJECT_ID)-$(ENV)-$(TF_VA
 # Lambda layer
 TF_VAR_uec_dos_tasks_python_libs = uec-dos-tasks-python-libs
 
-# Derive the security group for RDS
-# TF_VAR_db_identifier = uec-core-dos-pipeline-db-12
 TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg
-
-# pipeline rds = live-lk8s-nonprod-core-dos-db-rds-postgres-sg
 
 # Build slack secrets
 TF_VAR_sm_required = true

--- a/build/automation/var/profile/integration.mk
+++ b/build/automation/var/profile/integration.mk
@@ -32,7 +32,7 @@ TF_VAR_hk_integration_tester_lambda_function_name = $(PROJECT_ID)-$(ENV)-$(TF_VA
 # Lambda layer
 TF_VAR_uec_dos_tasks_python_libs = uec-dos-tasks-python-libs
 
-TF_VAR_db_security_group_name = live-lk8s-nonprod-core-dos-db-rds-postgres-sg
+TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg
 
 # Build slack secrets
 TF_VAR_sm_required = true

--- a/build/automation/var/profile/integration.mk
+++ b/build/automation/var/profile/integration.mk
@@ -32,8 +32,9 @@ TF_VAR_hk_integration_tester_lambda_function_name = $(PROJECT_ID)-$(ENV)-$(TF_VA
 # Lambda layer
 TF_VAR_uec_dos_tasks_python_libs = uec-dos-tasks-python-libs
 
-TF_VAR_db_security_group_name = live-lk8s-nonprod-core-dos-db-rds-postgres-sg
-#  aurora = uec-core-dos-integration-datastore-sg
+TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg
+# pipeline rds live-lk8s-nonprod-core-dos-db-rds-postgres-sg
+#  integration aurora = uec-core-dos-integration-datastore-sg
 
 # Build slack secrets
 TF_VAR_sm_required = true

--- a/build/automation/var/profile/integration.mk
+++ b/build/automation/var/profile/integration.mk
@@ -32,7 +32,8 @@ TF_VAR_hk_integration_tester_lambda_function_name = $(PROJECT_ID)-$(ENV)-$(TF_VA
 # Lambda layer
 TF_VAR_uec_dos_tasks_python_libs = uec-dos-tasks-python-libs
 
-TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg
+TF_VAR_db_security_group_name = live-lk8s-nonprod-core-dos-db-rds-postgres-sg
+#  aurora = uec-core-dos-integration-datastore-sg
 
 # Build slack secrets
 TF_VAR_sm_required = true

--- a/build/automation/var/profile/integration.mk
+++ b/build/automation/var/profile/integration.mk
@@ -31,8 +31,12 @@ TF_VAR_hk_integration_tester_name = hk-integration-tester
 TF_VAR_hk_integration_tester_lambda_function_name = $(PROJECT_ID)-$(ENV)-$(TF_VAR_hk_integration_tester_name)-lambda
 # Lambda layer
 TF_VAR_uec_dos_tasks_python_libs = uec-dos-tasks-python-libs
+
 # Derive the security group for RDS
-TF_VAR_db_identifier = uec-core-dos-pipeline-db-12
+# TF_VAR_db_identifier = uec-core-dos-pipeline-db-12
+TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg
+
+# pipeline rds = live-lk8s-nonprod-core-dos-db-rds-postgres-sg
 
 # Build slack secrets
 TF_VAR_sm_required = true

--- a/build/automation/var/profile/integration.mk
+++ b/build/automation/var/profile/integration.mk
@@ -32,10 +32,7 @@ TF_VAR_hk_integration_tester_lambda_function_name = $(PROJECT_ID)-$(ENV)-$(TF_VA
 # Lambda layer
 TF_VAR_uec_dos_tasks_python_libs = uec-dos-tasks-python-libs
 
-TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg
-#
-# pipeline rds live-lk8s-nonprod-core-dos-db-rds-postgres-sg
-#  integration aurora = uec-core-dos-integration-datastore-sg
+TF_VAR_db_security_group_name = live-lk8s-nonprod-core-dos-db-rds-postgres-sg
 
 # Build slack secrets
 TF_VAR_sm_required = true

--- a/build/automation/var/profile/integration.mk
+++ b/build/automation/var/profile/integration.mk
@@ -33,6 +33,7 @@ TF_VAR_hk_integration_tester_lambda_function_name = $(PROJECT_ID)-$(ENV)-$(TF_VA
 TF_VAR_uec_dos_tasks_python_libs = uec-dos-tasks-python-libs
 
 TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg
+#
 # pipeline rds live-lk8s-nonprod-core-dos-db-rds-postgres-sg
 #  integration aurora = uec-core-dos-integration-datastore-sg
 

--- a/build/automation/var/profile/live.mk
+++ b/build/automation/var/profile/live.mk
@@ -24,4 +24,5 @@ TF_VAR_splunk_firehose_role := dos_cw_w_events_firehose_access_role
 
 LAMBDA_VERSIONS_TO_RETAIN = 5
 
+#TODO can be changed to new SG when available in live 
 TF_VAR_db_security_group_name = live-lk8s-prod-core-dos-db-rds-postgres-sg

--- a/build/automation/var/profile/live.mk
+++ b/build/automation/var/profile/live.mk
@@ -24,5 +24,4 @@ TF_VAR_splunk_firehose_role := dos_cw_w_events_firehose_access_role
 
 LAMBDA_VERSIONS_TO_RETAIN = 5
 
-# Derive the security group for RDS
-TF_VAR_db_identifier = uec-core-dos-live-db-12
+TF_VAR_db_security_group_name = live-lk8s-prod-core-dos-db-rds-postgres-sg

--- a/build/automation/var/profile/nonprod.mk
+++ b/build/automation/var/profile/nonprod.mk
@@ -27,4 +27,4 @@ TF_VAR_splunk_firehose_role := dos_cw_w_events_firehose_access_role
 
 LAMBDA_VERSIONS_TO_RETAIN = 5
 
-TF_VAR_db_security_group_name = live-lk8s-nonprod-core-dos-db-rds-postgres-sg
+TF_VAR_db_security_group_name = uec-core-dos-integration-datastore-sg

--- a/build/automation/var/profile/nonprod.mk
+++ b/build/automation/var/profile/nonprod.mk
@@ -27,5 +27,4 @@ TF_VAR_splunk_firehose_role := dos_cw_w_events_firehose_access_role
 
 LAMBDA_VERSIONS_TO_RETAIN = 5
 
-# Derive the security group for RDS
-TF_VAR_db_identifier = uec-core-dos-pipeline-db-12
+TF_VAR_db_security_group_name = live-lk8s-nonprod-core-dos-db-rds-postgres-sg

--- a/build/automation/var/profile/put.mk
+++ b/build/automation/var/profile/put.mk
@@ -24,5 +24,4 @@ TF_VAR_splunk_firehose_role := dos-np_cw_w_events_firehose_access_role
 
 LAMBDA_VERSIONS_TO_RETAIN = 5
 
-# Derive the security group for RDS
-TF_VAR_db_identifier = uec-core-dos-put-db-12
+TF_VAR_db_security_group_name = live-lk8s-prod-core-dos-db-put-rds-postgres-sg

--- a/build/automation/var/profile/put.mk
+++ b/build/automation/var/profile/put.mk
@@ -24,4 +24,5 @@ TF_VAR_splunk_firehose_role := dos-np_cw_w_events_firehose_access_role
 
 LAMBDA_VERSIONS_TO_RETAIN = 5
 
+#TODO can be changed to new SG when available in live 
 TF_VAR_db_security_group_name = live-lk8s-prod-core-dos-db-put-rds-postgres-sg

--- a/build/jenkins/Jenkinsfile.hk-integration
+++ b/build/jenkins/Jenkinsfile.hk-integration
@@ -35,7 +35,7 @@ pipeline {
         DB_SUFFIX = 'tasks'
         PIPELINE_DATABASE = "${DB_PREFIX}_${ENVIRONMENT}"
         BUCKET = "uec-dos-tasks-${PROFILE}-housekeeping-bucket/${ENVIRONMENT}"
-        DB_HOST = 'uec-core-dos-pipeline-primary.dos-db-rds'
+        DB_HOST = 'uec-core-dos-integration-data.dos-db-rds'
         SLACK_CHANNEL = 'dos-tasks-integration-notifications'
         PATHWAYSDOS_V4_BRANCH = 'develop'
         BRANCH_NAME = sh(returnStdout: true, script: "make git-branch-format BRANCH_NAME=${GIT_BRANCH}").trim()

--- a/build/jenkins/Jenkinsfile.hk-integration
+++ b/build/jenkins/Jenkinsfile.hk-integration
@@ -35,7 +35,7 @@ pipeline {
         DB_SUFFIX = 'tasks'
         PIPELINE_DATABASE = "${DB_PREFIX}_${ENVIRONMENT}"
         BUCKET = "uec-dos-tasks-${PROFILE}-housekeeping-bucket/${ENVIRONMENT}"
-        DB_HOST = 'uec-core-dos-integration-data.dos-db-rds'
+        DB_HOST = 'uec-core-dos-pipeline-primary.dos-db-rds'
         SLACK_CHANNEL = 'dos-tasks-integration-notifications'
         PATHWAYSDOS_V4_BRANCH = 'develop'
         BRANCH_NAME = sh(returnStdout: true, script: "make git-branch-format BRANCH_NAME=${GIT_BRANCH}").trim()

--- a/infrastructure/stacks/security-groups/data.tf
+++ b/infrastructure/stacks/security-groups/data.tf
@@ -1,5 +1,9 @@
 
 # Look up for rds instance
-data "aws_db_instance" "rds_instance" {
-  db_instance_identifier = var.db_identifier
+# data "aws_db_instance" "rds_instance" {
+#   db_instance_identifier = var.db_identifier
+# }
+
+data "aws_security_group" "datastore" {
+  name = var.db_security_group_name
 }

--- a/infrastructure/stacks/security-groups/data.tf
+++ b/infrastructure/stacks/security-groups/data.tf
@@ -1,9 +1,3 @@
-
-# Look up for rds instance
-# data "aws_db_instance" "rds_instance" {
-#   db_instance_identifier = var.db_identifier
-# }
-
 data "aws_security_group" "datastore" {
   name = var.db_security_group_name
 }

--- a/infrastructure/stacks/security-groups/main.tf
+++ b/infrastructure/stacks/security-groups/main.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "hk_lambda_sg" {
     from_port       = 5432
     to_port         = 5432
     protocol        = "tcp"
-    security_groups = data.aws_db_instance.rds_instance.vpc_security_groups
+    security_groups = [data.aws_security_group.datastore.id]
   }
   egress {
     description = "AWS API Outbound Access"
@@ -24,7 +24,7 @@ resource "aws_security_group_rule" "db_sg_ingress" {
   from_port                = 5432
   to_port                  = 5432
   protocol                 = "tcp"
-  security_group_id        = element(tolist(data.aws_db_instance.rds_instance.vpc_security_groups), 0)
+  security_group_id        = data.aws_security_group.datastore.id
   source_security_group_id = aws_security_group.hk_lambda_sg.id
   description              = "A rule to allow incoming connections from hk lambda to RDS Security Group"
 }

--- a/infrastructure/stacks/security-groups/variables.tf
+++ b/infrastructure/stacks/security-groups/variables.tf
@@ -10,10 +10,6 @@ variable "vpc_terraform_state_key" {
 # # SG
 # ##############
 
-# variable "db_identifier" {
-#   description = "Identifer of RDS instance from which to extract the security group"
-# }
-
 variable "db_security_group_name" {
   description = "Identifier of security group attached to datastore"
 }

--- a/infrastructure/stacks/security-groups/variables.tf
+++ b/infrastructure/stacks/security-groups/variables.tf
@@ -10,6 +10,10 @@ variable "vpc_terraform_state_key" {
 # # SG
 # ##############
 
-variable "db_identifier" {
-  description = "Identifer of RDS instance from which to extract the security group"
+# variable "db_identifier" {
+#   description = "Identifer of RDS instance from which to extract the security group"
+# }
+
+variable "db_security_group_name" {
+    description = "Identifier of security group attached to datastore"
 }

--- a/infrastructure/stacks/security-groups/variables.tf
+++ b/infrastructure/stacks/security-groups/variables.tf
@@ -15,5 +15,5 @@ variable "vpc_terraform_state_key" {
 # }
 
 variable "db_security_group_name" {
-    description = "Identifier of security group attached to datastore"
+  description = "Identifier of security group attached to datastore"
 }


### PR DESCRIPTION
Change to find security group by name - rather than by datastore (because switching between rds and aurora complicates original approach). 
Change reference to prod profile to live to build live db name correctly
Forced upgrade in python formatter